### PR TITLE
cyber: extract IP from docker automatically instead of a fixed IP

### DIFF
--- a/cyber/setup.bash
+++ b/cyber/setup.bash
@@ -19,7 +19,9 @@ export PATH=${binary_path}:${recorder_path}:${monitor_path}:${launch_path}:${cha
 export PYTHONPATH=${PYTHON_LD_PATH}:${CYBER_PATH}/python:$PYTHONPATH
 
 export CYBER_DOMAIN_ID=80
-export CYBER_IP=172.17.0.1
+
+# extract IP automatically inside docker
+export CYBER_IP=`ifconfig docker0 | grep "inet addr" | cut -d":" -f2 | cut -d" " -f1`
 
 export GLOG_log_dir=/apollo/data/log
 export GLOG_alsologtostderr=0


### PR DESCRIPTION
Fix the problem due to different gateway IP from various docker versions.